### PR TITLE
Remove return type hint

### DIFF
--- a/src/Tool/FactoryCreator.php
+++ b/src/Tool/FactoryCreator.php
@@ -63,7 +63,7 @@ EOT;
      * @param $className
      * @return string
      */
-    private function getClassName($className):string
+    private function getClassName($className)
     {
         $class = substr($className, strrpos($className, '\\') + 1);
         return $class;


### PR DESCRIPTION
Removes return type hint that was included in `getClassName()` method definition, to ensure it will work with PHP 5.6.